### PR TITLE
Fix a compilation error

### DIFF
--- a/proof/proof_checker.cpp
+++ b/proof/proof_checker.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <iostream>
 #include <sstream>
+#include <math.h>
 
 using namespace std;
 using namespace pred;


### PR DESCRIPTION
The file `proof/proof_checker.cpp` uses the `pow` function from the
`math.h` lib but did not include the lib. This caused the following
error:

```
inductor/proof/proof_checker.cpp: In member function 'std::vector<std::vector<long unsigned int> > proof::EntailmentChecker::getChoiceFunctions(size_t, size_t)':
inductor/proof/proof_checker.cpp:888:52: error: 'pow' was not declared in this scope
         size_t numRows = (size_t) pow(arity, tuples);
                                                    ^
```